### PR TITLE
Converted tests into blackbox tests.

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -1,4 +1,4 @@
-package static
+package static_test
 
 import (
 	"fmt"
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/leighmcculloch/static"
 )
 
 func TestBuildSingle(t *testing.T) {
@@ -18,7 +20,7 @@ func TestBuildSingle(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir that does not exist.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir => %s", options.OutputDir)
@@ -31,7 +33,7 @@ func TestBuildSingle(t *testing.T) {
 	expectedOutputFilePath := filepath.Join(options.OutputDir, "hello", "world")
 	expectedOutputFileContents := "Hello world!"
 
-	status, outputPath, err := BuildSingle(options, handler, path)
+	status, outputPath, err := static.BuildSingle(options, handler, path)
 	t.Logf("BuildSingle(%#v) => %v, %v, %v", path, outputPath, status, err)
 	if (status != expectedStatus && outputPath != expectedOutputFilePath) || err != nil {
 		t.Errorf("BuildSingle(%#v) => %v, %v, %v, expected %v, nil", path, status, outputPath, err, expectedStatus)
@@ -56,7 +58,7 @@ func TestBuildSingleDirFilename(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir that does not exist.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir => %s", options.OutputDir)
@@ -71,7 +73,7 @@ func TestBuildSingleDirFilename(t *testing.T) {
 	expectedOutputFilePath := filepath.Join(options.OutputDir, "hello", "index.html")
 	expectedOutputFileContents := "Hello directory!"
 
-	status, outputPath, err := BuildSingle(options, handler, path)
+	status, outputPath, err := static.BuildSingle(options, handler, path)
 	t.Logf("BuildSingle(%#v) => %v, %v, %v", path, status, outputPath, err)
 	if (status != expectedStatus && outputPath != expectedOutputFilePath) || err != nil {
 		t.Errorf("BuildSingle(%#v) => %v, %v, %v, expected %v, %v, nil", path, status, outputPath, outputPath, err, expectedStatus)
@@ -96,7 +98,7 @@ func TestBuildSingleErrorsCreatingPath(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir => %s", options.OutputDir)
@@ -112,7 +114,7 @@ func TestBuildSingleErrorsCreatingPath(t *testing.T) {
 
 	expectedStatus := 0
 	expectedErrString := "Unable to create dir"
-	status, outputPath, err := BuildSingle(options, handler, path)
+	status, outputPath, err := static.BuildSingle(options, handler, path)
 	if err != nil && strings.Contains(err.Error(), expectedErrString) {
 		t.Logf("BuildSingle(%#v) => %v, %v, %v", path, status, outputPath, err)
 	} else {
@@ -128,7 +130,7 @@ func TestBuildSingleErrorsCannotCreateFileAtPath(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir => %s", options.OutputDir)
@@ -144,7 +146,7 @@ func TestBuildSingleErrorsCannotCreateFileAtPath(t *testing.T) {
 
 	expectedStatus := 0
 	expectedErrString := "Unable to create file"
-	status, outputPath, err := BuildSingle(options, handler, path)
+	status, outputPath, err := static.BuildSingle(options, handler, path)
 	if err != nil && strings.Contains(err.Error(), expectedErrString) {
 		t.Logf("BuildSingle(%#v) => %v, %v, %v", path, status, outputPath, err)
 	} else {
@@ -160,7 +162,7 @@ func TestBuildSingleErrorsInvalidPath(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir => %s", options.OutputDir)
@@ -172,7 +174,7 @@ func TestBuildSingleErrorsInvalidPath(t *testing.T) {
 
 	expectedStatus := 0
 	expectedErrString := "Unable to create http.Request for path"
-	status, outputPath, err := BuildSingle(options, handler, path)
+	status, outputPath, err := static.BuildSingle(options, handler, path)
 	if err != nil && strings.Contains(err.Error(), expectedErrString) {
 		t.Logf("BuildSingle(%#v) => %v, %v, %v", path, status, outputPath, err)
 	} else {
@@ -194,7 +196,7 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir that does not exist.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir: %s", options.OutputDir)
@@ -214,39 +216,39 @@ func TestBuild(t *testing.T) {
 	expected := []struct {
 		OutputFilePath     string
 		OutputFileContents string
-		Event              Event
+		Event              static.Event
 	}{
 		{
 			filepath.Join(options.OutputDir, "hello", "index.html"),
 			"Hello directory!",
-			Event{"build", "/hello/", 200, filepath.Join(options.OutputDir, "hello", "index.html"), nil},
+			static.Event{"build", "/hello/", 200, filepath.Join(options.OutputDir, "hello", "index.html"), nil},
 		},
 		{
 			filepath.Join(options.OutputDir, "hello", "go"),
 			"Hello go!",
-			Event{"build", "/hello/go", 200, filepath.Join(options.OutputDir, "hello", "go"), nil},
+			static.Event{"build", "/hello/go", 200, filepath.Join(options.OutputDir, "hello", "go"), nil},
 		},
 		{
 			filepath.Join(options.OutputDir, "hello", "world"),
 			"Hello world!",
-			Event{"build", "/hello/world", 200, filepath.Join(options.OutputDir, "hello", "world"), nil},
+			static.Event{"build", "/hello/world", 200, filepath.Join(options.OutputDir, "hello", "world"), nil},
 		},
 		{
 			filepath.Join(options.OutputDir, "hello", "universe"),
 			"Hello universe!",
-			Event{"build", "/hello/universe", 200, filepath.Join(options.OutputDir, "hello", "universe"), nil},
+			static.Event{"build", "/hello/universe", 200, filepath.Join(options.OutputDir, "hello", "universe"), nil},
 		},
 		{
 			filepath.Join(options.OutputDir, "bye"),
 			"404 page not found\n",
-			Event{"build", "/bye", 404, filepath.Join(options.OutputDir, "bye"), nil},
+			static.Event{"build", "/bye", 404, filepath.Join(options.OutputDir, "bye"), nil},
 		},
 	}
 
 	expectedNumberOfEvents := len(paths)
 	numberOfEvents := 0
-	events := make(chan Event, expectedNumberOfEvents)
-	Build(options, handler, paths, func(e Event) {
+	events := make(chan static.Event, expectedNumberOfEvents)
+	static.Build(options, handler, paths, func(e static.Event) {
 		select {
 		case events <- e:
 			t.Logf("Event received => %#v", e)
@@ -260,7 +262,7 @@ func TestBuild(t *testing.T) {
 		t.Errorf("Number of events received => %d, expected %d", numberOfEvents, expectedNumberOfEvents)
 	}
 
-	eventsSeen := make(map[Event]bool)
+	eventsSeen := make(map[static.Event]bool)
 	for event := range events {
 		if eventsSeen[event] {
 			t.Errorf("Event received => %#v, multiple times but was expected once.", event)
@@ -294,7 +296,7 @@ func TestBuildErrors(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir that does not exist.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir: %s", options.OutputDir)
@@ -314,8 +316,8 @@ func TestBuildErrors(t *testing.T) {
 
 	expectedNumberOfEvents := len(paths)
 	numberOfEvents := 0
-	events := make(chan Event, expectedNumberOfEvents)
-	Build(options, handler, paths, func(e Event) {
+	events := make(chan static.Event, expectedNumberOfEvents)
+	static.Build(options, handler, paths, func(e static.Event) {
 		select {
 		case events <- e:
 			t.Logf("Event received => %#v", e)
@@ -329,7 +331,7 @@ func TestBuildErrors(t *testing.T) {
 		t.Errorf("Number of events received => %d, expected %d", numberOfEvents, expectedNumberOfEvents)
 	}
 
-	eventsSeen := make(map[string]*Event)
+	eventsSeen := make(map[string]*static.Event)
 	for event := range events {
 		storeEvent := event
 		if eventsSeen[event.Path] != nil {
@@ -344,7 +346,7 @@ func TestBuildErrors(t *testing.T) {
 			t.Errorf("Event not received for path => %s, but was expected once.", path)
 		}
 
-		expectedAction := BUILD
+		expectedAction := static.BUILD
 		if event.Action != expectedAction {
 			t.Errorf("Event for %s Action => %s, expected %s.", path, event.Action, expectedAction)
 		}
@@ -370,7 +372,7 @@ func TestBuildWithNilEventHandler(t *testing.T) {
 	})
 
 	t.Log("And Options are defined with defaults and an OutputDir that does not exist.")
-	options := DefaultOptions
+	options := static.DefaultOptions
 	tempDir, _ := ioutil.TempDir("", "")
 	options.OutputDir = filepath.Join(tempDir, "build")
 	t.Logf("OutputDir: %s", options.OutputDir)
@@ -401,7 +403,7 @@ func TestBuildWithNilEventHandler(t *testing.T) {
 		},
 	}
 
-	Build(options, handler, paths, nil)
+	static.Build(options, handler, paths, nil)
 
 	for _, expect := range expected {
 		outputFileContents, err := ioutil.ReadFile(expect.OutputFilePath)

--- a/event_test.go
+++ b/event_test.go
@@ -1,18 +1,20 @@
-package static
+package static_test
 
 import (
 	"errors"
 	"testing"
+
+	"github.com/leighmcculloch/static"
 )
 
 func TestString(t *testing.T) {
 	tests := []struct {
-		event    Event
+		event    static.Event
 		expected string
 	}{
-		{Event{Action: "action", Path: "/path", StatusCode: 200, OutputPath: "/output-path/path"}, "Action: action, Path: /path, StatusCode: 200, OutputPath: /output-path/path"},
-		{Event{Action: "action", Path: "/path", StatusCode: 404, OutputPath: "/output-path/path"}, "Action: action, Path: /path, StatusCode: 404, OutputPath: /output-path/path"},
-		{Event{Action: "action", Path: "/path", StatusCode: 200, OutputPath: "/output-path/path", Error: errors.New("error")}, "Action: action, Path: /path, StatusCode: 200, OutputPath: /output-path/path, Error: error"},
+		{static.Event{Action: "action", Path: "/path", StatusCode: 200, OutputPath: "/output-path/path"}, "Action: action, Path: /path, StatusCode: 200, OutputPath: /output-path/path"},
+		{static.Event{Action: "action", Path: "/path", StatusCode: 404, OutputPath: "/output-path/path"}, "Action: action, Path: /path, StatusCode: 404, OutputPath: /output-path/path"},
+		{static.Event{Action: "action", Path: "/path", StatusCode: 200, OutputPath: "/output-path/path", Error: errors.New("error")}, "Action: action, Path: /path, StatusCode: 200, OutputPath: /output-path/path, Error: error"},
 	}
 
 	for _, test := range tests {

--- a/options_test.go
+++ b/options_test.go
@@ -1,12 +1,14 @@
-package static
+package static_test
 
 import (
 	"testing"
+
+	"github.com/leighmcculloch/static"
 )
 
 func TestDefaultOptions(t *testing.T) {
-	options := DefaultOptions
-	expected := Options{OutputDir: "build", Concurrency: 50, DirFilename: "index.html"}
+	options := static.DefaultOptions
+	expected := static.Options{OutputDir: "build", Concurrency: 50, DirFilename: "index.html"}
 
 	t.Logf("DefaultOptions => %#v", options)
 	if options != expected {


### PR DESCRIPTION
# What

Replaced `package static` with `package static_test` in tests that are
testing entirely exported functionality.
# Why

Blackbox testing is preferred as it results in tests that use the
package in the exact same way that another developer would use the
package.

Tests were originally written this way but it was changed when it was
discovered that the go cover tool was not including blackbox tests in
the coverage percentage.

According to golang/go#15795 the tests were not being included in the
package as because the package had been included into the blackbox tests
using the dot syntax (`import "."`). Importing using the fully qualified
package name fixes this, which is how the blackbox testing imports has
been implemented in this commit.
